### PR TITLE
Using statcast_pitches package for memory efficient BaseballVideoScraper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pip==24.0
 pybaseball==2.2.7
 pytest==8.3.2
 ultralytics>=8.2.90
+git+https://github.com/Jensen-holm/statcast-era-pitches.git


### PR DESCRIPTION
utilizing [statcast_pitches](https://github.com/Jensen-holm/statcast-era-pitches) package to effeciently load data into pandas. Before, we were loading the entire dataset and then filtering. Now, we filter before hand using the query parameter in statcast_pitches.load() which is a lot more memory efficient & faster than pybaseball for large queries.

**Change**: `scripts/savant_scraper.py`

```python

class BaseballSavVideoScraper:
    ...

    def playids_for_date_range(self, start_date, end_date, team: str = None, pitch_call: str = None):
        """
        Retrieves PlayIDs for games played within date range. Can filter by team or pitch call.
        """

        # this could be changed to only select needed columns
        statcast_query = f"""
            SELECT *
            FROM pitches
            WHERE 
                game_date >= '{start_date}'
                AND game_date <= '{end_date}'
                AND (home_team = '{team}' OR away_team = '{team}');
            """

        # statcast_pitches repository: https://github.com/Jensen-holm/statcast-era-pitches
        statcast_df = statcast_pitches.load(query=statcast_query, pandas=True) 
        ...
    ...
```

Loading all the data at once in pandas results in unnecessary memory consumption of 12+ GB, which would expend all of my system RAM. With this new approach, we only load exactly what is needed. 