### PR TITLE
Fixed bad statcast_pitches query that failed when team = None

### DIFF
--- a/scripts/savant_scraper.py
+++ b/scripts/savant_scraper.py
@@ -145,7 +145,7 @@ class BaseballSavVideoScraper:
             statcast_query += f" AND (home_team =? OR away_team =?)"
 
         # statcast_pitches repository: https://github.com/Jensen-holm/statcast-era-pitches
-        params = (start_date, end_date) if team is None else (start_date, end_date, team)
+        params = (start_date, end_date) if team is None else (start_date, end_date, team, team)
         statcast_df = statcast_pitches.load(query=f"{statcast_query};", params=params).to_pandas()
 
         game_pks = statcast_df['game_pk'].unique()


### PR DESCRIPTION
       
change: `scripts/savant_scraper.BaseballSavVideoScraper.playids_for_date_range()`

```python

        ...
        # this could be changed to only select needed columns
        statcast_query = f"""
            SELECT *
            FROM pitches
            WHERE 
                game_date >=? AND game_date <=?
        """
        
        if team is not None:
            statcast_query += f" AND (home_team =? OR away_team =?)"

        # statcast_pitches repository: https://github.com/Jensen-holm/statcast-era-pitches
        params = (start_date, end_date) if team is None else (start_date, end_date, team, team)
        statcast_df = statcast_pitches.load(query=f"{statcast_query};", params=params).to_pandas()
        ...
```

I believe this worked on my system, I am not as familiar with this project though. I would make sure that this works how you want it to before merging. 