### PR TITLE
Solving statcast era pitches issues

### DIFF
--- a/scripts/savant_scraper.py
+++ b/scripts/savant_scraper.py
@@ -6,6 +6,8 @@ from bs4 import BeautifulSoup
 import time
 import shutil
 import statcast_pitches
+import polars as pl
+import pybaseball
 
 '''Class BaseballSavVideoScraper based on code from BSav_Scraper_Vid Repo, which can be found at https://github.com/dylandru/BSav_Scraper_Vid'''
 
@@ -128,25 +130,20 @@ class BaseballSavVideoScraper:
             df = df.loc[df['pitch_call'] == pitch_call]
         return df
 
-    def playids_for_date_range(self, start_date, end_date, team: str = None, pitch_call: str = None):
+    def playids_for_date_range(self, start_date: pd.Timestamp, end_date: pd.Timestamp, team: str = None, pitch_call: str = None):
         """
         Retrieves PlayIDs for games played within date range. Can filter by team or pitch call.
         """
 
-        # this could be changed to only select needed columns
-        statcast_query = f"""
-            SELECT *
-            FROM pitches
-            WHERE 
-                game_date >=? AND game_date <=?
-        """
-        
-        if team is not None:
-            statcast_query += f" AND (home_team =? OR away_team =?)"
-
-        # statcast_pitches repository: https://github.com/Jensen-holm/statcast-era-pitches
-        params = (start_date, end_date) if team is None else (start_date, end_date, team, team)
-        statcast_df = statcast_pitches.load(query=f"{statcast_query};", params=params).to_pandas()
+        statcast_df = (statcast_pitches.load()
+                        .filter(
+                            (pl.col("game_date").dt.date() >= start_date) & 
+                            (pl.col("game_date") <= start_date),
+                            (pl.col("home_team") == team) |
+                            (pl.col("away_team") == team) 
+                            if team is not None else pl.lit(True))
+                        .collect()
+                        .to_pandas())
 
         game_pks = statcast_df['game_pk'].unique()
         dfs = [self.process_game_data(self.fetch_game_data(game_pk), pitch_call=pitch_call) for game_pk in game_pks]

--- a/scripts/savant_scraper.py
+++ b/scripts/savant_scraper.py
@@ -145,7 +145,7 @@ class BaseballSavVideoScraper:
             statcast_query += f" AND (home_team =? OR away_team =?)"
 
         # statcast_pitches repository: https://github.com/Jensen-holm/statcast-era-pitches
-        params = (start_date, end_date) if team is None else (start_date, end_date, team)
+        params = (start_date, end_date) if team is None else (start_date, end_date, team, team)
         statcast_df = statcast_pitches.load(query=f"{statcast_query};", params=params).to_pandas()
 
         game_pks = statcast_df['game_pk'].unique()


### PR DESCRIPTION
**changes**: `scripts/savant_scraper.BaseballSavVideoScraper.playids_for_date_range()`

```python
        ... 
        statcast_df = (statcast_pitches.load()
                        .filter(
                            (pl.col("game_date").dt.date() >= start_date) & 
                            (pl.col("game_date") <= start_date),
                            (pl.col("home_team") == team) |
                            (pl.col("away_team") == team) 
                            if team is not None else pl.lit(True))
                        .collect()
                        .to_pandas())
        ...
```


changing the code to this actually allowed the program to run on my computer finally without running out of RAM. Let me know what you think. 

The reason this works is because I changed the statcast_pitches code to lazy load the dataset into a polars lazy frame instead of a dataframe. 