### PR TITLE
Fix Name Bug in Video Download from Scraper

### DIFF
--- a/scripts/savant_scraper.py
+++ b/scripts/savant_scraper.py
@@ -125,7 +125,8 @@ class BaseballSavVideoScraper:
         """Process game data and filter by pitch_call if provided."""
         team_home_data = game_data.get('team_home', [])
         df = pd.json_normalize(team_home_data)
-        df['game_pk'] = game_data.get('game_pk')
+        for entry in df:
+            df['game_pk'] = df['game_pk']
         if pitch_call:
             df = df.loc[df['pitch_call'] == pitch_call]
         return df


### PR DESCRIPTION
Fixed lines correctly pulls game_pks from the Statcast API. Downloaded videos should now have the corrected `{game_pk}_{play_id}.mp4` format.