### PR TITLE
Add Discord Message Workflow for Merged PR

### DIFF
--- a/.github/workflows/discord_pr.yml
+++ b/.github/workflows/discord_pr.yml
@@ -1,0 +1,17 @@
+name: Discord PR Notification
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  discord_notification:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Discord notification
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.PR_DISCORD_WEBHOOK }}
+        uses: Ilshidur/action-discord@master
+        with:
+          args: '**New PR Merged**\n\nPR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}\n\nCreated by: ${{ github.event.pull_request.user.login }}\nMerged by: ${{ github.event.pull_request.merged_by.login }}\n\nDescription:\n${{ github.event.pull_request.body }}\n\n[View Pull Request](${{ github.event.pull_request.html_url }})'


### PR DESCRIPTION
Adds workflow to use the [https://github.com/Ilshidur/action-discord](url) repository in order to notify BaseballCV discord users whenever a PR is merged. 