### PR TITLE
Edit Automated Annotation to include AutoDistill

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,11 @@ With that given dataset, you can then use our automatic annotation tool to annot
   data_tools = DataTools()
 
   # Annotate photos folder based on glove tracking model with a confidence threshold of 60%
-  data_tools.automated_annotation(model_alias="glove_tracking", dataset_path="photos", conf=0.6)
+  data_tools.automated_annotation(model_alias="glove_tracking", dataset_path="photos", conf=0.6, mode="legacy")
+
+  # Annotate photos folder based on glove ontology using Autodistill
+  ontology = { "a mitt worn by a baseball player for catching a baseball": "glove" }
+  data_tools.automated_annotation(dataset_path="photos", mode="autodistill", ontology=ontology)
 ```
 
 More datasets and tools will likely be added in the future, so check back!

--- a/baseballcv/functions/README.md
+++ b/baseballcv/functions/README.md
@@ -7,6 +7,7 @@ This directory contains the functions used in the project.
 - `load_tools.py`: Contains a class LoadTools containing functions for both loading the raw and annotated datasets as well as the available models.
 - `dataset_tools.py`: Contains a class DataTools to generate and manipulate datasets.
 - `savant_scraper.py`: Contains a class BaseballSavVideoScraper to scrape baseball videos from Savant.
+- `baseball_tools.py`: Contains a class BaseballTools to analyze baseball data and create data from video.
 - `function_utils/utils.py`: Contains utility functions used across the project.
 
 ### load_tools.py
@@ -20,6 +21,13 @@ Key function(s):
 - `load_model(model_alias: str, model_type: str = 'YOLO', use_bdl_api: Optional[bool] = True, model_txt_path: Optional[str] = None) -> str`: 
   Loads a given baseball computer vision model into the repository. It can use either a model alias or a file path to a text file containing the download link.
 
+### baseball_tools.py
+
+#### `BaseballTools` class
+
+Key function(s):
+- `distance_to_zone(start_date: str = "2024-05-01", end_date: str = "2024-05-01", team_abbr: str = None, pitch_type: str = None, player: int = None, max_videos: int = None, max_videos_per_game: int = None, create_video: bool = True, catcher_model: str = 'phc_detector', glove_model: str = 'glove_tracking', ball_model: str = 'ball_trackingv4', zone_vertical_adjustment: float = 0.5, save_csv: bool = True, csv_path: str = None) -> list`: The DistanceToZone function calculates the distance of a pitch to the strike zone in a video, as well as other information about the Play ID including the frame where the ball crosses, and the distance between the target and the estimated strike zone.
+
 ### dataset_tools.py
 
 #### `DataTools` class
@@ -27,7 +35,7 @@ Key function(s):
 Key function(s):
 - `generate_photo_dataset(max_plays=5000, max_num_frames=10000, max_videos_per_game=10, start_date="2024-05-01", end_date="2024-07-31", delete_savant_videos=True)`: Generates a photo dataset from a diverse set of baseball videos from Savant.
 
-- `automated_annotation(model_alias: str, dataset_path: str, conf: float = 0.6)`: Automatically annotates a given dataset using a pre-trained YOLOmodel.
+- `automated_annotation(model_alias: str = None, model_type: str = 'detection', image_dir: str = "cv_dataset", output_dir: str = "labeled_dataset", conf: float = .80, device: str = 'cpu', mode: str = 'autodistill', ontology: dict = None, extension: str = '.jpg') -> str`: Automatically annotates images using pre-trained YOLO model from BaseballCV repo or Autodistill library depending on the mode specified. The annotated output consists of image files in the output directory, and label files in the subfolder "annotations" to work with annotation tools.
 
 ### savant_scraper.py
 

--- a/docs/datasets/index.md
+++ b/docs/datasets/index.md
@@ -179,12 +179,24 @@ data_tools.generate_photo_dataset(
     end_date="2024-05-31"
 )
 
-# Auto-annotate using existing model
+# Auto-annotate using existing model w/ YOLO
 data_tools.automated_annotation(
     model_alias="ball_tracking",
     image_dir="custom_dataset",
     output_dir="annotated_dataset",
-    conf=0.8
+    conf=0.8,
+    mode="legacy"
+)
+
+# Auto-annotate using existing model w/ Autodistill
+ontology = { "a mitt worn by a baseball player for catching a baseball": "glove" }
+data_tools.automated_annotation(
+    model_type="detection",
+    image_dir="custom_dataset",
+    output_dir="annotated_dataset",
+    conf=0.8,
+    mode="autodistill",
+    ontology=ontology
 )
 ```
 

--- a/docs/using-repository/training-pipeline.md
+++ b/docs/using-repository/training-pipeline.md
@@ -59,7 +59,8 @@ class BaseballTrainingPipeline:
             model_alias="ball_tracking",
             image_dir="raw_dataset",
             output_dir="annotated_dataset",
-            conf=0.8
+            conf=0.8,
+            mode="legacy"
         )
 
     def train_model(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,9 @@ dependencies = [
     "coco-eval==0.0.4",
     "pytorch-lightning==2.5.0",
     "polars==1.10.0",
-    "mediapipe==0.10.21"
+    "mediapipe==0.10.21",
+    "autodistill==0.1.29",
+    "autodistill-grounded-sam==0.1.2"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,7 @@ polars==1.10.0
 mediapipe==0.10.21
 datasets==3.4.0
 rfdetr==1.0.8
+autodistill==0.1.29
+autodistill-grounded-sam==0.1.2
 git+https://github.com/Jensen-holm/statcast-era-pitches.git
 git+https://github.com/dylandru/yolov9.git

--- a/tests/test_functions/test_dataset_tools.py
+++ b/tests/test_functions/test_dataset_tools.py
@@ -68,7 +68,8 @@ class TestDatasetTools:
             assert frame.endswith(('.jpg', '.png')), f'Invalid frame format {frame}'
 
     @pytest.mark.network
-    def test_automated_annotation(self, setup, data_tools, load_tools):
+    @pytest.mark.parametrize("mode, value", [("mode", "autodistill"), ("mode", "legacy")])
+    def test_automated_annotation(self, setup, data_tools, load_tools, mode, value):
         """
         Tests the annotation tools to make sure the proper file systems are loaded 
         and manipulated.
@@ -87,23 +88,41 @@ class TestDatasetTools:
             delete_savant_videos=True
         )
 
+        ontology = { "a mitt worn by a baseball player for catching a baseball": "glove" } if value == "autodistill" else None
+
+        legacy_annotation_dir = tempfile.mkdtemp()
+        autodistill_annotation_dir = tempfile.mkdtemp()
+        annotation_dir = legacy_annotation_dir if value != "autodistill" else autodistill_annotation_dir
+
         with tempfile.TemporaryDirectory() as annotation_dir:
             data_tools.automated_annotation(
                 model_alias="glove_tracking",
                 model_type="detection",
                 image_dir=temp_dir,
-                output_dir=annotation_dir,
-                conf=0.5
+                output_dir=annotation_dir if value != "autodistill" else f"{annotation_dir}_autodistill",
+                conf=0.5,
+                mode=value,
+                ontology=ontology
             )
             assert os.path.exists(annotation_dir)
-            assert os.path.exists(os.path.join(annotation_dir, "annotations"))
-            
-            images = os.listdir(annotation_dir)
-            annotations = os.listdir(os.path.join(annotation_dir, "annotations"))
-            assert len(images) > 0, "Should have copied some images"
-            assert len(annotations) > 0, "Should have generated some annotations"
-            
-            for ann_file in annotations:
-                assert ann_file.endswith('.txt'), f"Invalid annotation format: {ann_file}"
 
-        os.remove(load_tools.yolo_model_aliases['glove_tracking'].replace('.txt', '.pt')) # Remove the loaded pytorch file
+            if value != "autodistill":
+                assert os.path.exists(os.path.join(annotation_dir, "annotations"))
+                images = os.listdir(annotation_dir)
+                annotations = os.listdir(os.path.join(annotation_dir, "annotations"))
+                assert len(images) > 0, "Should have copied some images"
+                assert len(annotations) > 0, "Should have generated some annotations"
+                
+                for ann_file in annotations:
+                    assert ann_file.endswith('.txt'), f"Invalid annotation format: {ann_file}"
+                
+                os.remove(load_tools.yolo_model_aliases['glove_tracking'].replace('.txt', '.pt')) # Remove the loaded pytorch file
+
+            else:
+                assert os.path.exists(os.path.join(f"{annotation_dir}_autodistill", "train", "labels")), "Should have labels"
+                assert os.path.exists(os.path.join(f"{annotation_dir}_autodistill", "train", "images")), "Should have images"
+                assert os.path.exists(os.path.join(f"{annotation_dir}_autodistill", "data.yaml")), "Should have data.yaml"
+                images = os.listdir(os.path.join(f"{annotation_dir}_autodistill", "train", "images"))
+                annotations = os.listdir(os.path.join(f"{annotation_dir}_autodistill", "train", "labels"))
+                assert len(images) > 0, "Should have copied some images"
+                assert len(annotations) > 0, "Should have generated some annotations"


### PR DESCRIPTION
Given that the currently functionality in the Automated Annotation Function only includes use with our pre-trained YOLO Models, an update to the `DataTools` class was needed for support within the function to have [AutoDistill](https://docs.autodistill.com/). AutoDistill is a library designed to use large models to generate annotations in hopes of creating annotations for smaller models to be trained on - more can be found at their GH: [AutoDistill GitHub](https://github.com/autodistill/autodistill).