### PR TITLE
Update AutoDistill to Batch Image Processing

### DIFF
--- a/baseballcv/functions/README.md
+++ b/baseballcv/functions/README.md
@@ -35,7 +35,7 @@ Key function(s):
 Key function(s):
 - `generate_photo_dataset(max_plays=5000, max_num_frames=10000, max_videos_per_game=10, start_date="2024-05-01", end_date="2024-07-31", delete_savant_videos=True)`: Generates a photo dataset from a diverse set of baseball videos from Savant.
 
-- `automated_annotation(model_alias: str = None, model_type: str = 'detection', image_dir: str = "cv_dataset", output_dir: str = "labeled_dataset", conf: float = .80, device: str = 'cpu', mode: str = 'autodistill', ontology: dict = None, extension: str = '.jpg') -> str`: Automatically annotates images using pre-trained YOLO model from BaseballCV repo or Autodistill library depending on the mode specified. The annotated output consists of image files in the output directory, and label files in the subfolder "annotations" to work with annotation tools.
+- `automated_annotation(model_alias: str = None, model_type: str = 'detection', image_dir: str = "cv_dataset", output_dir: str = "labeled_dataset", conf: float = .80, device: str = 'cpu', mode: str = 'autodistill', ontology: dict = None, extension: str = '.jpg', batch_size: int = 100) -> str`: Automatically annotates images using pre-trained YOLO model from BaseballCV repo or Autodistill library depending on the mode specified. The annotated output consists of image files in the output directory, and label files in the subfolder "annotations" to work with annotation tools.
 
 ### savant_scraper.py
 

--- a/tests/test_functions/test_dataset_tools.py
+++ b/tests/test_functions/test_dataset_tools.py
@@ -102,7 +102,8 @@ class TestDatasetTools:
                 output_dir=annotation_dir if value != "autodistill" else f"{annotation_dir}_autodistill",
                 conf=0.5,
                 mode=value,
-                ontology=ontology
+                ontology=ontology,
+                batch_size=100
             )
             assert os.path.exists(annotation_dir)
 


### PR DESCRIPTION
## Adding Batching for Automated Annotation
When trying to work with AutoDistill and `DataTools.automated_annotation` function, it was a common occurence where large runs would stop running completely in the middle of processing and not yield any annotations. To avoid this, images will now be processed in batches so that the outputs are saved at the end of each batch processing. This was implemented so that the user should not have to alter their current implementation of this function in any capacity. 